### PR TITLE
Add LD_LIBRARY_PATH in env block

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -157,6 +157,7 @@ env {
     MRTRIX_NTHREADS=1
     OMP_NUM_THREADS=1
     OPENBLAS_NUM_THREADS=1
+    LD_LIBRARY_PATH="/usr/local/lib/python2.7/dist-packages/vtk"
 }
 
 if(params.output_dir) {


### PR DESCRIPTION
We have a VTK error due to a missing path in LD_LIBRARY_PATH. I added it in env block in the nextflow.config.